### PR TITLE
Fix calling add() on the DirWriter before it is "ready".

### DIFF
--- a/lib/dir-writer.js
+++ b/lib/dir-writer.js
@@ -37,6 +37,7 @@ DirWriter.prototype._create = function () {
     // ready to start getting entries!
     me.ready = true
     me.emit("ready")
+    me._process()
   })
 }
 


### PR DESCRIPTION
The simple `cp` example was acting very weird for me. I guess this is why.
