### PR TITLE
Fix bug that causes premature 'end' event

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -290,13 +290,13 @@ Writer.prototype._finish = function () {
   return
 
   function setProps (current) {
+    todo += 3
     endChmod(me, me.props, current, me._path, next("chmod"))
     endChown(me, me.props, current, me._path, next("chown"))
-    endUtimes(me, me.props, current, me._path, next("chown"))
+    endUtimes(me, me.props, current, me._path, next("utimes"))
   }
 
   function next (what) {
-    todo ++
     return function (er) {
       // console.error("   W Finish", what, todo)
       if (errState) return
@@ -387,4 +387,3 @@ function objectToString (d) {
 function isDate(d) {
   return typeof d === 'object' && objectToString(d) === '[object Date]';
 }
-


### PR DESCRIPTION
Since endChmod may call its callback directly, todo may hit 1 and then
0 without this change.  This bug was causing tar extraction by node-tar
to emit 'end' before the final chown and utimes.
