### PR TITLE
fix FileWriter.write to always return true or false (not undefined)

### DIFF
--- a/lib/file-writer.js
+++ b/lib/file-writer.js
@@ -72,7 +72,11 @@ FileWriter.prototype.write = function (c) {
 
   // allow 2 buffered writes, because otherwise there's just too
   // much stop and go bs.
-  return ret || (me._stream._queue ? (me._stream._queue.length <= 2) : false)
+  if (ret === false && me._stream._queue) {
+    return me._stream._queue.length <= 2;
+  } else {
+    return ret;
+  }
 }
 
 FileWriter.prototype.end = function (c) {


### PR DESCRIPTION
Since streams in 0.10 no longer have a _queue, FileWriter.write will return
undefined instead of false when the underlying fs write stream returned false.

This simple change makes it always return either true or false.
