### PR TITLE
Passing follow link in DirReader through to child readers

### DIFF
--- a/lib/dir-reader.js
+++ b/lib/dir-reader.js
@@ -209,7 +209,7 @@ DirReader.prototype.getChildProps = function (stat) {
   return { depth: this.depth + 1
          , root: this.root || this
          , parent: this
-         , follow: this.follow
+         , follow: this.props.follow
          , filter: this.filter
          , sort: this.props.sort
          , hardlinks: this.props.hardlinks


### PR DESCRIPTION
Fixes a bug where symlinks in directories cause a stream error
