### PR TITLE
Fix #24 (dependencies typo)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "graceful-fs": "3",
     "inherits": "~2.0.0",
-    "mkdirp": ">=0.5 0",
+    "mkdirp": ">=0.5.0",
     "rimraf": "2"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix #24.
In my case, the error message was:

> Error: No compatible version found: mkdirp@'>=0.50.0-'
