### PR TITLE
rm unused fs, fstream

### DIFF
--- a/lib/dir-writer.js
+++ b/lib/dir-writer.js
@@ -6,9 +6,7 @@
 
 module.exports = DirWriter
 
-var fs = require("graceful-fs")
-  , fstream = require("../fstream.js")
-  , Writer = require("./writer.js")
+var Writer = require("./writer.js")
   , inherits = require("inherits")
   , mkdir = require("mkdirp")
   , path = require("path")


### PR DESCRIPTION
Removed unused `fs`, `fstream` in `dir-writer.js`.