### PR TITLE
fix file-writer: add error listener

### DIFF
--- a/lib/file-writer.js
+++ b/lib/file-writer.js
@@ -47,6 +47,8 @@ FileWriter.prototype._create = function () {
     me.emit("drain")
   })
 
+  me._stream.on("error", function (error) { me.emit("error") })
+  
   me._stream.on("drain", function () { me.emit("drain") })
 
   me._stream.on("close", function () {


### PR DESCRIPTION
Add error listener in `file-writer.js`.
Without this any program that use module `fstream` would crash when read error occurs:
```js
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: EACCES, open '/path/to/file'
```