### PR TITLE
file-reader: rm duplicate declaration of Reader

### DIFF
--- a/lib/file-reader.js
+++ b/lib/file-reader.js
@@ -4,7 +4,6 @@ module.exports = FileReader
 
 var fs = require("graceful-fs")
   , fstream = require("../fstream.js")
-  , Reader = fstream.Reader
   , inherits = require("inherits")
   , mkdir = require("mkdirp")
   , Reader = require("./reader.js")


### PR DESCRIPTION
In `file-reader` variable `Reader` declared twice.