### PR TITLE
Fix for #36

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -195,7 +195,7 @@ function endChmod (me, want, current, path, cb) {
 function endChown (me, want, current, path, cb) {
   // Don't even try it unless root.  Too easy to EPERM.
   if (process.platform === "win32") return cb()
-  if (!process.getuid || !process.getuid() === 0) return cb()
+  if (!process.getuid || process.getuid() !== 0) return cb()
   if (typeof want.uid !== "number" &&
       typeof want.gid !== "number" ) return cb()
 


### PR DESCRIPTION
- fixes #36: endChown will not fail on process.getuid() !== 0