### PR TITLE
standard

### DIFF
--- a/examples/filter-pipe.js
+++ b/examples/filter-pipe.js
@@ -87,13 +87,15 @@ function missile (entry) {
   }
 }
 
-function runaway (entry) { return function () {
-  var e = Math.random() < 0.5
-  console.error(indent + '%s %s',
-                entry.basename,
-                e ? 'turns to flee' : 'is vanquished!')
-  indent = indent.slice(0, -1)
-}}
+function runaway (entry) {
+  return function () {
+    var e = Math.random() < 0.5
+    console.error(indent + '%s %s',
+                  entry.basename,
+                  e ? 'turns to flee' : 'is vanquished!')
+    indent = indent.slice(0, -1)
+  }
+}
 
 w.on('entry', attacks)
 // w.on('ready', function () { attacks(w) })

--- a/examples/pipe.js
+++ b/examples/pipe.js
@@ -82,13 +82,15 @@ function missile (entry) {
   }
 }
 
-function runaway (entry) { return function () {
-  var e = Math.random() < 0.5
-  console.error(indent + '%s %s',
-                entry.basename,
-                e ? 'turns to flee' : 'is vanquished!')
-  indent = indent.slice(0, -1)
-}}
+function runaway (entry) {
+  return function () {
+    var e = Math.random() < 0.5
+    console.error(indent + '%s %s',
+                  entry.basename,
+                  e ? 'turns to flee' : 'is vanquished!')
+    indent = indent.slice(0, -1)
+  }
+}
 
 w.on('entry', attacks)
 // w.on('ready', function () { attacks(w) })

--- a/lib/collect.js
+++ b/lib/collect.js
@@ -30,37 +30,39 @@ function collect (stream) {
   // replace the pipe method with a new version that will
   // unlock the buffered stuff.  if you just call .pipe()
   // without a destination, then it'll re-play the events.
-  stream.pipe = (function (orig) { return function (dest) {
-    // console.error(' === open the pipes', dest && dest.path)
+  stream.pipe = (function (orig) {
+    return function (dest) {
+      // console.error(' === open the pipes', dest && dest.path)
 
-    // let the entries flow through one at a time.
-    // Once they're all done, then we can resume completely.
-    var e = 0
-    ;(function unblockEntry () {
-      var entry = entryBuffer[e++]
-      // console.error(" ==== unblock entry", entry && entry.path)
-      if (!entry) return resume()
-      entry.on('end', unblockEntry)
-      if (dest) dest.add(entry)
-      else stream.emit('entry', entry)
-    })()
+      // let the entries flow through one at a time.
+      // Once they're all done, then we can resume completely.
+      var e = 0
+      ;(function unblockEntry () {
+        var entry = entryBuffer[e++]
+        // console.error(" ==== unblock entry", entry && entry.path)
+        if (!entry) return resume()
+        entry.on('end', unblockEntry)
+        if (dest) dest.add(entry)
+        else stream.emit('entry', entry)
+      })()
 
-    function resume () {
-      stream.removeListener('entry', saveEntry)
-      stream.removeListener('data', save)
-      stream.removeListener('end', save)
+      function resume () {
+        stream.removeListener('entry', saveEntry)
+        stream.removeListener('data', save)
+        stream.removeListener('end', save)
 
-      stream.pipe = orig
-      if (dest) stream.pipe(dest)
+        stream.pipe = orig
+        if (dest) stream.pipe(dest)
 
-      buf.forEach(function (b) {
-        if (b) stream.emit('data', b)
-        else stream.emit('end')
-      })
+        buf.forEach(function (b) {
+          if (b) stream.emit('data', b)
+          else stream.emit('end')
+        })
 
-      stream.resume()
+        stream.resume()
+      }
+
+      return dest
     }
-
-    return dest
-  }})(stream.pipe)
+  })(stream.pipe)
 }

--- a/lib/file-reader.js
+++ b/lib/file-reader.js
@@ -43,8 +43,9 @@ FileReader.prototype._getStream = function () {
     // console.error('\t\t%d %s', c.length, self.basename)
     self._bytesEmitted += c.length
     // no point saving empty chunks
-    if (!c.length) return
-    else if (self._paused || self._buffer.length) {
+    if (!c.length) {
+      return
+    } else if (self._paused || self._buffer.length) {
       self._buffer.push(c)
       self._read()
     } else self.emit('data', c)

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -162,8 +162,9 @@ Reader.prototype._stat = function (currentStat) {
     if (handleHardlinks && type !== 'Directory' && props.nlink && props.nlink > 1) {
       var k = props.dev + ':' + props.ino
       // console.error("Reader has nlink", self._path, k)
-      if (hardLinks[k] === self._path || !hardLinks[k]) hardLinks[k] = self._path
-      else {
+      if (hardLinks[k] === self._path || !hardLinks[k]) {
+        hardLinks[k] = self._path
+      } else {
         // switch into hardlink mode.
         type = self.type = self.props.type = 'Link'
         self.Link = self.props.Link = true


### PR DESCRIPTION
`standard` got a bit stricter. Here's a PR to fix up `fstream` for you.

I expect that `standard` will not change very much going forward, so this type of tweaking shouldn't be necessary in the future. I also [added this repo to our test suite](https://github.com/feross/standard/blob/master/test.js#L48) so we don't accidentally make a rule stricter in the future.

Peace :+1: 