### PR TITLE
Pass error object through error events

### DIFF
--- a/lib/file-writer.js
+++ b/lib/file-writer.js
@@ -47,7 +47,7 @@ FileWriter.prototype._create = function () {
     self.emit('drain')
   })
 
-  self._stream.on('error', function () { self.emit('error') })
+  self._stream.on('error', function (e) { self.emit('error', e) })
 
   self._stream.on('drain', function () { self.emit('drain') })
 


### PR DESCRIPTION
I observed a `tar.Extract` firing an `error` event with no error, and traced it back to this.