### PR TITLE
deps: Upgrade graceful-fs dependency to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=0.6"
   },
   "dependencies": {
-    "graceful-fs": "3",
+    "graceful-fs": "^4.1.2",
     "inherits": "~2.0.0",
     "mkdirp": ">=0.5 0",
     "rimraf": "2"


### PR DESCRIPTION
graceful-fs used to monkey-patch node's core fs module.
This has been fixed in the version 4.

Related: https://github.com/nodejs/node/pull/2714