### PR TITLE
make collect() respect stream pause/resume state

### DIFF
--- a/lib/collect.js
+++ b/lib/collect.js
@@ -3,6 +3,8 @@ module.exports = collect
 function collect (stream) {
   if (stream._collected) return
 
+  if (stream._paused) return stream.on('resume', collect.bind(null, stream))
+
   stream._collected = true
   stream.pause()
 

--- a/lib/dir-reader.js
+++ b/lib/dir-reader.js
@@ -24,7 +24,6 @@ function DirReader (props) {
   }
 
   self.entries = null
-  self._entries = []
   self._index = -1
   self._paused = false
   self._length = -1
@@ -48,7 +47,6 @@ DirReader.prototype._getEntries = function () {
     if (er) return self.error(er)
 
     self.entries = entries
-    self._entries = entries.slice()
 
     self.emit('entries', entries)
     if (self._paused) self.once('resume', processEntries)
@@ -76,7 +74,7 @@ DirReader.prototype._read = function () {
   }
 
   self._index++
-  if (self._index >= self._entries.length) {
+  if (self._index >= self.entries.length) {
     if (!self._ended) {
       self._ended = true
       self.emit('end')
@@ -85,14 +83,12 @@ DirReader.prototype._read = function () {
     return
   }
 
-  // save creating a proxy, by stat'ing the thing now.
-  var nextEntry = self._entries[self._index]
-  if (!nextEntry) return this._read()
-
   // ok, handle this one, then.
-  var p = path.resolve(self._path, nextEntry)
+
+  // save creating a proxy, by stat'ing the thing now.
+  var p = path.resolve(self._path, self.entries[self._index])
   assert(p !== self._path)
-  assert(nextEntry)
+  assert(self.entries[self._index])
 
   // set this to prevent trying to _read() again in the stat time.
   self._currentEntry = p


### PR DESCRIPTION
* Reverts a55ae72b23e6cdd6c540dac896a361060c56dd17 / @evanlucas / as this only masks part of the problem and ends up with an incorrect list of entries anyway. 

* Adds a line in `collect()` that makes it properly respect state so the ignore list gets to be properly built before fstream starts reading entries.

Explained in commit message:

Without watching if a stream is already paused before calling pause(),
collect() can conflict with other users of the stream who may be
managing state, resulting in a premature collect().
This manifests in the fstream-npm and node-tar combination where
fstream-npm manages state in readBundledLinks() at the same time
collect() is processing the stream. collect() ends up running before
fstream-npm has properly set up the _correct_ list of entries according
to the ignore rules. When collect() gets to run before this is complete,
fstream starts performing _read() operations on a non-filtered list,
keeping track of entry index, then after it starts, fstream-npm inserts
a new list of entries and the entry index is incorrect and can skip
files.