### PR TITLE
Move props.path check below class init

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -21,10 +21,6 @@ function Reader (props, currentStat) {
     props = { path: props }
   }
 
-  if (!props.path) {
-    self.error('Must provide a path', null, true)
-  }
-
   // polymorphism.
   // call fstream.Reader(dir) to get a DirReader object, etc.
   // Note that, unlike in the Writer case, ProxyReader is going
@@ -84,6 +80,10 @@ function Reader (props, currentStat) {
   }
 
   Abstract.call(self)
+
+  if (!props.path) {
+    self.error('Must provide a path', null, true)
+  }
 
   self.readable = true
   self.writable = false

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -30,8 +30,6 @@ function Writer (props, current) {
     props = { path: props }
   }
 
-  if (!props.path) self.error('Must provide a path', null, true)
-
   // polymorphism.
   // call fstream.Writer(dir) to get a DirWriter object, etc.
   var type = getType(props)
@@ -60,6 +58,8 @@ function Writer (props, current) {
   // now get down to business.
 
   Abstract.call(self)
+
+  if (!props.path) self.error('Must provide a path', null, true)
 
   // props is what we want to set.
   // set some convenience properties as well.


### PR DESCRIPTION
`self.error` is not available until the prototype is available

Before:

```
fstream.Writer({})
// TypeError: self.error is not a function
```

After:

```
fstream.Writer({})
// Error: Must provide a path
```
