### PR TITLE
Reader does not work when read hardlink

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -155,25 +155,6 @@ Reader.prototype._stat = function (currentStat) {
     self.size = props.size
 
     var type = getType(props)
-    var handleHardlinks = props.hardlinks !== false
-
-    // special little thing for handling hardlinks.
-    if (handleHardlinks && type !== 'Directory' && props.nlink && props.nlink > 1) {
-      var k = props.dev + ':' + props.ino
-      // console.error("Reader has nlink", self._path, k)
-      if (hardLinks[k] === self._path || !hardLinks[k]) {
-        hardLinks[k] = self._path
-      } else {
-        // switch into hardlink mode.
-        type = self.type = self.props.type = 'Link'
-        self.Link = self.props.Link = true
-        self.linkpath = self.props.linkpath = hardLinks[k]
-        // console.error("Hardlink detected, switching mode", self._path, self.linkpath)
-        // Setting __proto__ would arguably be the "correct"
-        // approach here, but that just seems too wrong.
-        self._stat = self._read = LinkReader.prototype._read
-      }
-    }
 
     if (self.type && self.type !== type) {
       self.error('Unexpected type: ' + type)


### PR DESCRIPTION
I think the following code must be deleted.
Because the hardlink will be read by LinkReader. But the hardlink is just file.Trust me!
```
   var handleHardlinks = props.hardlinks !== false

    // special little thing for handling hardlinks.
    if (handleHardlinks && type !== 'Directory' && props.nlink && props.nlink > 1) {
      var k = props.dev + ':' + props.ino
      // console.error("Reader has nlink", self._path, k)
      if (hardLinks[k] === self._path || !hardLinks[k]) {
        hardLinks[k] = self._path
      } else {
        // switch into hardlink mode.
        type = self.type = self.props.type = 'Link'
        self.Link = self.props.Link = true
        self.linkpath = self.props.linkpath = hardLinks[k]
        // console.error("Hardlink detected, switching mode", self._path, self.linkpath)
        // Setting __proto__ would arguably be the "correct"
        // approach here, but that just seems too wrong.
        self._stat = self._read = LinkReader.prototype._read
      }
    }
```