### PR TITLE
Avoid using deprecated Buffer API

### DIFF
--- a/lib/collect.js
+++ b/lib/collect.js
@@ -12,7 +12,15 @@ function collect (stream) {
   stream.on('end', save)
   var buf = []
   function save (b) {
-    if (typeof b === 'string') b = new Buffer(b)
+    if (typeof b === 'string') {
+      if (Buffer.from && Buffer.from !== Uint8Array.from) {
+        b = Buffer.from(b)
+      } else {
+        // Outdated Node.js versions (<4.5.0 or 5.x <5.10)
+        // b is already type-checked to be a string just above
+        b = new Buffer(b)
+      }
+    }
     if (Buffer.isBuffer(b) && !b.length) return
     buf.push(b)
   }


### PR DESCRIPTION
Use `Buffer.from` when it's available instead of `new Bufer(string)`

Fixes: https://github.com/npm/fstream/issues/60
Refs: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor
Tracking: https://github.com/nodejs/node/issues/19079

Given that this is a highly popular module and that Buffer constructor was used in a single place, I decided to add a minimal polyfill in-place (like I do in other similar situations) instead of adding a dependnecy.

/cc @zkat 