### PR TITLE
update graceful-fs to 4.2.2 to be compatible with node 12.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=0.6"
   },
   "dependencies": {
-    "graceful-fs": "^4.1.2",
+    "graceful-fs": "^4.2.2",
     "inherits": "~2.0.0",
     "mkdirp": ">=0.5 0",
     "rimraf": "2"


### PR DESCRIPTION
# What / Why
update graceful-fs to 4.2.2 to be compatible with node 12.
> n/a

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
