### PR TITLE
Fixed mkdirp version 

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "graceful-fs": "^4.1.2",
     "inherits": "~2.0.0",
-    "mkdirp": ">=0.5 0",
+    "mkdirp": "^0.5 0",
     "rimraf": "2"
   },
   "devDependencies": {


### PR DESCRIPTION
#fixed issue #66  changed >= to ^ for mkdirp dependency for it build on Node-8 

## References
https://github.com/npm/fstream/issues/66