### PR TITLE
dep: remove mkdirp dependency

### DIFF
--- a/lib/dir-writer.js
+++ b/lib/dir-writer.js
@@ -7,8 +7,8 @@
 module.exports = DirWriter
 
 var Writer = require('./writer.js')
+var nodeFs = require('fs')
 var inherits = require('inherits')
-var mkdir = require('mkdirp')
 var path = require('path')
 var collect = require('./collect.js')
 
@@ -31,7 +31,7 @@ function DirWriter (props) {
 
 DirWriter.prototype._create = function () {
   var self = this
-  mkdir(self._path, Writer.dirmode, function (er) {
+  nodeFs.mkdir(self._path, { recursive: true }, function (er) {
     if (er) return self.error(er)
     // ready to start getting entries!
     self.ready = true

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -1,9 +1,9 @@
 module.exports = Writer
 
+var nodeFs = require('fs')
 var fs = require('graceful-fs')
 var inherits = require('inherits')
 var rimraf = require('rimraf')
-var mkdir = require('mkdirp')
 var path = require('path')
 var umask = process.platform === 'win32' ? 0 : process.umask()
 var getType = require('./get-type.js')
@@ -166,7 +166,7 @@ function create (self) {
 
   // XXX Need to clobber non-dirs that are in the way,
   // unless { clobber: false } in the props.
-  mkdir(path.dirname(self._path), Writer.dirmode, function (er, made) {
+  nodeFs.mkdir(path.dirname(self._path), { recursive: true }, function (er, made) {
     // console.error("W created", path.dirname(self._path), er)
     if (er) return self.error(er)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
       "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -25,7 +26,8 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
@@ -1121,6 +1123,7 @@
                     },
                     "semver": {
                       "version": "4.3.6",
+                      "resolved": false,
                       "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
                       "dev": true
                     }
@@ -2567,6 +2570,7 @@
         },
         "tap-parser": {
           "version": "1.1.5",
+          "resolved": false,
           "integrity": "sha1-BvHF1U1rmXsDxlUjF8SPt5kGk+M=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "graceful-fs": "^4.1.2",
     "inherits": "~2.0.0",
-    "mkdirp": "^0.5 0",
     "rimraf": "2"
   },
   "devDependencies": {


### PR DESCRIPTION
# What / Why

* dep: mkdirp hasn't been updated in 4 years, and node's fs library
has had a recursive option for `fs` since v10.12 (oldest active LTS
version). Additionally `mkdirp` depends on a version of library `minimist` that has a minor vulnerability associated.

## Refs:
* https://nodejs.org/api/fs.html#fs_fs_mkdir_path_options_callback
* https://npmjs.com/advisories/1179